### PR TITLE
Upgrade to Netty 4.1.50.Final and Netty_tcnative 2.0.31.Final 

### DIFF
--- a/sdk/boms/azure-sdk-bom/pom.xml
+++ b/sdk/boms/azure-sdk-bom/pom.xml
@@ -259,49 +259,49 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-buffer</artifactId>
-        <version>4.1.49.Final</version>
+        <version>4.1.50.Final</version>
       </dependency>
 
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-http2</artifactId>
-        <version>4.1.49.Final</version>
+        <version>4.1.50.Final</version>
       </dependency>
 
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-http</artifactId>
-        <version>4.1.49.Final</version>
+        <version>4.1.50.Final</version>
       </dependency>
 
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler-proxy</artifactId>
-        <version>4.1.49.Final</version>
+        <version>4.1.50.Final</version>
       </dependency>
 
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>
-        <version>4.1.49.Final</version>
+        <version>4.1.50.Final</version>
       </dependency>
 
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>2.0.29.Final</version>
+        <version>2.0.31.Final</version>
       </dependency>
 
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>4.1.49.Final</version>
+        <version>4.1.50.Final</version>
       </dependency>
 
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-unix-common</artifactId>
-        <version>4.1.49.Final</version>
+        <version>4.1.50.Final</version>
       </dependency>
 
       <dependency>

--- a/sdk/core/azure-core-http-netty/cgmanifest.json
+++ b/sdk/core/azure-core-http-netty/cgmanifest.json
@@ -6,7 +6,7 @@
                 "Maven": {
                     "ArtifactId": "netty-handler-proxy",
                     "GroupId": "io.netty",
-                    "Version": "4.1.49.Final"
+                    "Version": "4.1.50.Final"
                 }
             }
         }


### PR DESCRIPTION
Hi

Package Owner: Shweta Singh

Patch Details : Modified pom.xml to update netty version to '4.1.50.Final' and netty_tcnative to '2.0.31.Final'

Testing Detail:
Verified working by executing 'mvn test' command and all test cases are running fine on x86 and aarch64 both platforms.

PR Description :
- Upgrade Netty and Netty_tcnative to its latest version which includes both security fixes and AArch64 performance improvements. 
Refer release notes for detail: https://netty.io/news/2020/05/13/4-1-50-Final.html